### PR TITLE
Fix initial notification message sample

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -737,7 +737,7 @@ document.getElementById("app-restartbutton").addEventListener("click",function()
 				<section>
 						<h3>Creating Desktop Notifications</h3>
 						<pre><code class="hljs noti-create" contenteditable>
-var notification = fin.desktop.Notification({
+var notification = new fin.desktop.Notification({
     url: "notification.html",
     message:"This is a notification message"
 });


### PR DESCRIPTION
The first notification sample doesn't work properly.  It needs `new` before the `notification` call.